### PR TITLE
fix:index.d.ts: remove nested declare modifier for TS1038

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -244,7 +244,7 @@ export declare namespace MET {
    * @param to target language code(s). `en` by default.
    * @param options optional translate options
    */
-  declare function translate(
+  function translate(
     text: string | string[],
     from: string | null | undefined,
     to: string | string[],

--- a/scripts/index.tpl.d.ts
+++ b/scripts/index.tpl.d.ts
@@ -107,7 +107,7 @@ export declare namespace MET {
    * @param to target language code(s). `en` by default.
    * @param options optional translate options
    */
-  declare function translate(
+  function translate(
     text: string | string[],
     from: string | null | undefined,
     to: string | string[],


### PR DESCRIPTION
The generated `index.d.ts` after running `npm run gen:config` seems to nest a `declare` inside another `declare`  scope which the typescript compiler plains about with this message:
`node_modules/bing-translate-api/index.d.ts(247,3): error TS1038: A 'declare' modifier cannot be used in an already ambient context..`
https://github.com/microsoft/TypeScript/blob/42bb138173e3b3869b6a6f68d277c7172387a4cf/src/compiler/diagnosticMessages.json#L114-L117

This points to an issue inside the `generate-config.js`. But you might have a better idea of what is happening here.