### PR TITLE
fix: avoid throwing error when `detectedLang` is not present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ async function translate(text, from, to, correct, raw, userAgent, proxyAgents) {
   )
 
   const translation = body[0].translations[0]
-  const detectedLang = body[0].detectedLanguage
+  const detectedLang = body[0].detectedLanguage || {}
 
   /**
    * @type {TranslationResult}


### PR DESCRIPTION
We know that not in all scenarios bing will return the detectedLang field, which needs to be handled in a compatible manner.


Please refer to https://learn.microsoft.com/en-us/azure/ai-services/translator/reference/v3-0-translate

> A successful response is a JSON array with one result for each string in the input array. A result object includes the following properties:
> 
> detectedLanguage: An object describing the detected language through the following properties:
> 
> language: A string representing the code of the detected language.
> 
> score: A float value indicating the confidence in the result. The score is between zero and one and a low score indicates a low confidence.
> 
> The detectedLanguage property is only present in the result object when language autodetection is requested.